### PR TITLE
Update segmentation tutorial to use docker by default

### DIFF
--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -79,7 +79,7 @@ First, let's install it:
 3. Use the default settings, except: <br/> <img className="max-w-[400px]" src="/img/tutorials/windows-x11-1.webp"/>
 4. Check that the X Server is running in the tray: <br/> <img className="max-w-[400px]" src="/img/tutorials/windows-x11-2.webp"/>
 5. Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/).
-6. Pull the latest docker image by running `docker pull ghcr.io/spacegaier/volume-cartographer:edge`
+6. Pull the latest Docker image by running `docker pull ghcr.io/spacegaier/volume-cartographer:edge`
 7. Put the extracted `campfire` directory in `C:\campfire` (or update the path in the Docker command below).
 8. Then run:
 

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -109,7 +109,7 @@ Install [Homebrew](https://brew.sh/). Run `brew install --no-quarantine educelab
 5. Quit XQuartz and restart it.
 6. Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/).
 7. Put the extracted `campfire` directory in your home dir (or update the path in the Docker command below).
-8. Pull the latest docker image by running `docker pull ghcr.io/spacegaier/volume-cartographer:edge`
+8. Pull the latest Docker image by running `docker pull ghcr.io/spacegaier/volume-cartographer:edge`
 9. Then run:
 
 ```bash

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -63,6 +63,8 @@ These instructions are created using a fork of the original Volume Cartographer 
 
 the -v switch used below is mapping a local path (or volume) to the docker container, for example: in the below commands it is mapping c:\campfire to /campfire at the root of the container. You can modify this however you'd like. To check if your paths have been created properly you can run the docker container and initiate a list command by typing `docker run -v c:\campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge ls` where ls at the end is your list command (you could insert most anything here).
 
+If you are running linux you will most likely have to add 'sudo' to the beginning of any of the docker commands.
+
 :::
 
 First, let's install it:
@@ -213,7 +215,7 @@ We will use the main `VC` GUI app to perform segmentation of the campfire scroll
   <figcaption className="mt-0">Segmentation: finding a surface of papyrus.</figcaption>
 </figure>
 
-Run `VC` on the command line to open the GUI app (or `open /Applications/VC.app` on macOS with Homebrew).
+Run ` docker run -v c:\campfire:/campfire -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/spacegaier/volume-cartographer:edge VC` on the command line to open the GUI app (or `open /Applications/VC.app` on macOS with Homebrew).
 
 Now open the `campfire.volpkg` directory using *“File > Open volpkg”*. You should see something like this:
 
@@ -305,6 +307,8 @@ cd campfire.volpkg/working
 Now run `vc_render` with the following arguments, substituting `<your-segment-id>`:
 
 ```bash
+#to run this command on the regular scroll data, just change the -v mapping after docker run and the -v mapping after vc_layers_from_ppm to the correct path
+
 # From within campfire.volpkg/working
 docker run -v c:\campfire:/campfire ghcr.io/educelab/volume-cartographer:edge vc_render -v campfire/campfire.volpkg -s <your-segment-id> 
 
@@ -388,6 +392,9 @@ The `out.ppm` file that we generated with `vc_render` contains a mapping between
 To generate the surface volume, we need to run one more program:
 
 ```bash
+
+#to run this command on the regular scroll data, just change the -v mapping after docker run and the -v mapping after vc_layers_from_ppm to the correct path
+
 # From within campfire.volpkg/working
 mkdir layers
 

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -61,7 +61,7 @@ To perform segmentation and flattening, we'll use [Volume Cartographer](https://
 
 These instructions are created using a fork of the original Volume Cartographer software created by @spacegaier. This is the current version that the segmentation team is using. The repository is located here: https://github.com/spacegaier/volume-cartographer
 
-the -v switch used below is mapping a local path (or volume) to the docker container, for example: in the below commands it is mapping c:\campfire to /campfire at the root of the container. You can modify this however you'd like. To check if your paths have been created properly you can run the docker container and initiate a list command by typing `docker run -v c:\campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge ls` where ls at the end is your list command (you could insert most anything here).
+The -v switch used below is mapping a local path (or volume) to the Docker container. For example, in the below commands it is mapping c:\campfire to /campfire at the root of the container. You can modify this however you'd like. To check if your paths have been created properly you can run the Docker container and initiate a list command by typing `docker run -v c:\campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge ls` where 'ls' at the end is your list command (you could insert most anything here).
 
 If you are running linux you will most likely have to add 'sudo' to the beginning of any of the docker commands.
 

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -295,7 +295,7 @@ docker run -v c:\campfire:/campfire ghcr.io/educelab/volume-cartographer:edge vc
 
 ### Rendering the segment
 
-In order to see the content on the surface of our segment, we need to flatten and texture the segment using the `vc_render` tool. While the output from `vc_render` is considered a "final result" that can be placed anywhere, our convention is to place all results in a `working` directory within the `.volpkg` so that all data is kept together. You can also create this folder in your normal file explorer window
+In order to see the content on the surface of our segment, we need to flatten and texture the segment using the `vc_render` tool. While the output from `vc_render` is considered a "final result" that can be placed anywhere, our convention is to place all results in a `working` directory within the `.volpkg` so that all data is kept together. You can also create this folder in your normal file explorer window.
 
 Ensure you are in the correct working directory before running these:
 

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -63,7 +63,7 @@ These instructions are created using a fork of the original Volume Cartographer 
 
 The -v switch used below is mapping a local path (or volume) to the Docker container. For example, in the below commands it is mapping c:\campfire to /campfire at the root of the container. You can modify this however you'd like. To check if your paths have been created properly you can run the Docker container and initiate a list command by typing `docker run -v c:\campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge ls` where 'ls' at the end is your list command (you could insert most anything here).
 
-If you are running linux you will most likely have to add 'sudo' to the beginning of any of the docker commands.
+If you are running Linux you will most likely have to add 'sudo' to the beginning of any of the Docker commands.
 
 :::
 

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -84,7 +84,7 @@ First, let's install it:
 8. Then run:
 
 ```bash
-docker run -it -v C:\campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/spacegaier/volume-cartographer:edge VC
+docker run -it -v C:\campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/spacegaier/volume-cartographer:edge
 ```
 
   </TabItem>
@@ -117,10 +117,10 @@ Install [Homebrew](https://brew.sh/). Run `brew install --no-quarantine educelab
 xhost +localhost
 
 # M1 chips:
-docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" --platform linux/arm64 ghcr.io/spacegaier/volume-cartographer:edge VC
+docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" --platform linux/arm64 ghcr.io/spacegaier/volume-cartographer:edge
 
 # Intel chips:
-docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/spacegaier/volume-cartographer:edge VC
+docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/spacegaier/volume-cartographer:edge
 ```
 
 
@@ -136,7 +136,7 @@ docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" gh
 ```bash
 xhost +local:docker
 
-docker run -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge VC
+docker run -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge
 ```
 
 

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -59,7 +59,9 @@ To perform segmentation and flattening, we'll use [Volume Cartographer](https://
 
 :::tip
 
-We’re using the original version of Volume Cartographer in this tutorial. For the latest version, see the [Community Projects](community_projects#volume-cartographer) page or ask in Discord.
+These instructions are created using a fork of the original Volume Cartographer software created by @spacegaier. This is the current version that the segmentation team is using. The repository is located here: https://github.com/spacegaier/volume-cartographer
+
+the -v switch used below is mapping a local path (or volume) to the docker container, for example: in the below commands it is mapping c:\campfire to /campfire at the root of the container. You can modify this however you'd like. To check if your paths have been created properly you can run the docker container and initiate a list command by typing `docker run -v c:\campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge ls` where ls at the end is your list command (you could insert most anything here).
 
 :::
 
@@ -75,11 +77,12 @@ First, let's install it:
 3. Use the default settings, except: <br/> <img className="max-w-[400px]" src="/img/tutorials/windows-x11-1.webp"/>
 4. Check that the X Server is running in the tray: <br/> <img className="max-w-[400px]" src="/img/tutorials/windows-x11-2.webp"/>
 5. Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/).
-6. Put the extracted `campfire` directory in `C:\` (or update the path in the Docker command below).
-7. Then run:
+6. Pull the latest docker image by running `docker pull ghcr.io/spacegaier/volume-cartographer:edge`
+7. Put the extracted `campfire` directory in `C:\campfire` (or update the path in the Docker command below).
+8. Then run:
 
 ```bash
-docker run -it -v C:\campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/educelab/volume-cartographer
+docker run -it -v C:\campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/spacegaier/volume-cartographer:edge VC
 ```
 
   </TabItem>
@@ -104,17 +107,18 @@ Install [Homebrew](https://brew.sh/). Run `brew install --no-quarantine educelab
 5. Quit XQuartz and restart it.
 6. Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/).
 7. Put the extracted `campfire` directory in your home dir (or update the path in the Docker command below).
-8. Then run:
+8. Pull the latest docker image by running `docker pull ghcr.io/spacegaier/volume-cartographer:edge`
+9. Then run:
 
 ```bash
 # Allow network connections to XQuartz:
 xhost +localhost
 
 # M1 chips:
-docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" --platform linux/arm64 ghcr.io/educelab/volume-cartographer
+docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" --platform linux/arm64 ghcr.io/spacegaier/volume-cartographer:edge VC
 
 # Intel chips:
-docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/educelab/volume-cartographer
+docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" ghcr.io/spacegaier/volume-cartographer:edge VC
 ```
 
 
@@ -123,13 +127,14 @@ docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" gh
 
 * We assume that you’re running the X Window System (if you’re unsure, you probably do).
 * First, install [Docker](https://docs.docker.com/engine/install/). Do *not* use Snap to install it.
+* Pull the latest 
 * Put the extracted `campfire` directory in your home dir (or update the path in the Docker command below).
 * Then run:
 
 ```bash
 xhost +local:docker
 
-docker run -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/campfire:/campfire ghcr.io/educelab/volume-cartographer
+docker run -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/campfire:/campfire ghcr.io/spacegaier/volume-cartographer:edge VC
 ```
 
 
@@ -170,7 +175,7 @@ make install
 Volume Cartographer works on `.volpkg` directories, which is a custom format just for Volume Cartographer. Let’s create one using the `vc_packager` tool, by feeding it the tomographically reconstructed volume (represented as a .tif stack) of the [campfire scroll](/data):
 
 ```bash
-vc_packager -v campfire.volpkg -m 1000 -s ~/campfire/rec/ # Or /campfire/rec when using Docker
+docker run -v c:\campfire:/campfire vc_packager ghcr.io/educelab/volume-cartographer:edge -v campfire/campfire.volpkg -m 1000 -s ~/campfire/rec/ # Or /campfire/rec when using Docker
 ```
 
 The material-thickness flag `-m` is an estimate of the papyrus thickness in microns and is used to help Volume Cartographer's tools automatically decide on good default parameters. The defaults can always be overridden later, so even though it's required, don't worry too much about this value.
@@ -283,12 +288,14 @@ If you notice a discrepancy where the points of your segment are no longer align
 You created your first segment! Be sure to save it using *“File > Save volpkg”*. The point cloud for this segment is stored in `campfire.volpkg/paths/<your-segment-id>/pointset.vcps`. If you want to view the point cloud in MeshLab, you can convert it to an OBJ file using `vc_convert_pointset`:
 
 ```bash
-vc_convert_pointset -i campfire.volpkg/paths/<your-segment-id>/pointset.vcps -o points.obj
+docker run -v c:\campfire:/campfire ghcr.io/educelab/volume-cartographer:edge vc_convert_pointset -i campfire/campfire.volpkg/paths/<your-segment-id>/pointset.vcps -o points.obj
 ```
 
 ### Rendering the segment
 
-In order to see the content on the surface of our segment, we need to flatten and texture the segment using the `vc_render` tool. While the output from `vc_render` is considered a "final result" that can be placed anywhere, our convention is to place all results in a `working` directory within the `.volpkg` so that all data is kept together:
+In order to see the content on the surface of our segment, we need to flatten and texture the segment using the `vc_render` tool. While the output from `vc_render` is considered a "final result" that can be placed anywhere, our convention is to place all results in a `working` directory within the `.volpkg` so that all data is kept together. You can also create this folder in your normal file explorer window
+
+Ensure you are in the correct working directory before running these:
 
 ```bash
 mkdir campfire.volpkg/working
@@ -299,7 +306,8 @@ Now run `vc_render` with the following arguments, substituting `<your-segment-id
 
 ```bash
 # From within campfire.volpkg/working
-vc_render -v ../ -s <your-segment-id> -o out.obj --output-ppm out.ppm
+docker run -v c:\campfire:/campfire ghcr.io/educelab/volume-cartographer:edge vc_render -v campfire/campfire.volpkg -s <your-segment-id> 
+
 ```
 
 If you don't remember your segment's ID, you can use `vc_volpkg_explorer` to list all segment IDs, or type `../paths/2023`, hit Tab to autocomplete, and then remove the `../paths/` prefix (e.g. `-s $(basename ../path/20230315130225)`).
@@ -382,7 +390,9 @@ To generate the surface volume, we need to run one more program:
 ```bash
 # From within campfire.volpkg/working
 mkdir layers
-vc_layers_from_ppm -v ../ -p out.ppm --output-dir layers/
+
+docker run -v c:\campfire:/campfire ghcr.io/educelab/volume-cartographer:edge vc_layers_from_ppm -v campfire/campfire.volpkg -p campfire/campfire.volpkg/working/PerPixelMap.ppm --output-dir campfire/campfire.volpkg/working/layers -f tif -r 32
+
 ```
 
 Now in the `layers` directory you’ll find another image stack! You can open this in Fiji again, which should then look something like this:

--- a/docs/06_tutorial3.md
+++ b/docs/06_tutorial3.md
@@ -129,7 +129,7 @@ docker run -it -v ~/campfire:/campfire --env="DISPLAY=host.docker.internal:0" gh
 
 * We assume that you’re running the X Window System (if you’re unsure, you probably do).
 * First, install [Docker](https://docs.docker.com/engine/install/). Do *not* use Snap to install it.
-* Pull the latest 
+* Pull the latest Docker image by running `docker pull ghcr.io/spacegaier/volume-cartographer:edge`
 * Put the extracted `campfire` directory in your home dir (or update the path in the Docker command below).
 * Then run:
 

--- a/docs/07_tutorial4.md
+++ b/docs/07_tutorial4.md
@@ -218,7 +218,7 @@ There are some defaults in the InferenceArgumentParser class, but it also accept
 ```
 these all can be passed as arguments. ex: `python inference_timesformer.py --segment_id 20231210121321 20231221180251 --segment_path $(pwd)/train_scrolls --model_path timesformer_wild15_20230702185753_0_fr_i3depoch=12.ckpt`
 
-advanced: to change the number of layers the model runs inference on, you must change the following:
+Advanced: to change the number of layers the model runs inference on, you must change the following:
 
 ```bash
 

--- a/docs/07_tutorial4.md
+++ b/docs/07_tutorial4.md
@@ -156,6 +156,8 @@ Now let’s create a model! This part of the tutorial is over [on Kaggle as a no
 
 To run more advanced models on the [scroll segments](data_segments), check out the winning code from the [First Letters Prize](firstletters) and the [2023 Grand Prize](grandprize).
 
+### Running the 2023 Grand Prize model
+
 To run the Grand Prize winning model: 
 
 1. Create a folder somewhere on your machine you'd like to store both the model and also the segment data and open a terminal from within it

--- a/docs/07_tutorial4.md
+++ b/docs/07_tutorial4.md
@@ -155,3 +155,97 @@ So how can a machine learning model detect ink? In the electron microscope image
 Now let’s create a model! This part of the tutorial is over [on Kaggle as a notebook](https://www.kaggle.com/code/jpposma/vesuvius-challenge-ink-detection-tutorial).
 
 To run more advanced models on the [scroll segments](data_segments), check out the winning code from the [First Letters Prize](firstletters) and the [2023 Grand Prize](grandprize).
+
+To run the Grand Prize winning model: 
+
+1. Create a folder somewhere on your machine you'd like to store both the model and also the segment data and open a terminal from within it
+2. Clone the Grand Prize repo:
+
+```bash
+git clone https://github.com/younader/Vesuvius-Grandprize-Winner.git
+cd Vesuvius-Grandprize-Winner
+```
+3. Download and install anaconda or miniconda from: https://www.anaconda.com/download
+
+4. Create a new Conda env and activate it
+
+```bash
+conda create -n vesuviusgp
+conda activate vesuviusgp
+```
+5. Install the requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+At this point you have the model and all the requirements on your pc. The current inference and training scripts use relative paths, all starting from the directory from which you cloned the repository.
+
+What this means is that when you run the inference or training scripts, they are starting from that directory, and looking for the folders from there. 
+
+The following directory structure is required, unless you want to modify the paths in the script. Note that the segment name and the _mask.png and _inklabels.png must match.  
+.
+└── Vesuvius-Grandprize-Winner-main/
+    ├── eval_scrolls/
+    │   └── segment1/
+    │       ├── layers/
+    │       │   └── 00.tif
+    │       └── segment1_mask.png
+    └── train_scrolls/
+        └── segment1/
+            ├── layers/
+            │   └── 00.tif
+            ├── segment1_mask.png
+            └── segment1_inklabels.png
+
+For inference; 
+There are some defaults in the InferenceArgumentParser class, but it also accepts them as inputs
+
+```bash
+    segment_id: list[str] =['20230925002745'] #this accepts multiple segments, just keep in mind all these must exist in eval_scrolls, unless you change the segment_path
+    segment_path:str='./eval_scrolls' #the path to the segments
+    model_path:str= 'outputs/vesuvius/pretraining_all/vesuvius-models/valid_20230827161847_0_fr_i3depoch=7.ckpt' #the path to the checkpoint you downloaded or created and want to use for inference
+    out_path:str="" #path to output predictions
+    stride: int = 2 #the amount of pixels to skip when sliding the window, default is 2, you can run this up to 32 with no real difference in quality but a substantial increase to speed
+    start_idx:int=15 
+    workers: int = 4 #number of threads to use, increase or decrease depending on your specs, not to exceed number of threads avail
+    batch_size: int = 512 #increase or decrease depending on hardware, would have some difficulty above 512 on regular consumer hardware. if you get CUDA: out of memoery errors, lower this or increase stride, or both
+    size:int=64 #window size
+    reverse:int=0 #use to reverse the order of the layers during inference
+    device:str='cuda' #change to cpu or mps if on device with no gpu or apple device, respectively
+```
+these all can be passed as arguments. ex: `python inference_timesformer.py --segment_id 20231210121321 20231221180251 --segment_path $(pwd)/train_scrolls --model_path timesformer_wild15_20230702185753_0_fr_i3depoch=12.ckpt`
+
+advanced: to change the number of layers the model runs inference on, you must change the following:
+
+```bash
+
+    in the read_image_mask function, where it is defined
+
+    read_image_mask(fragment_id,start_idx=18,end_idx=38,rotation=0) #modify the start_idx and the end_idx
+
+    in the RegressionPLModel class, in the self.backbone=TimeSformer attributes,
+
+    num_frames = 30 #change this to the number of images you want to use. TimeSformer is just treating each image as a frame in a video
+
+```
+For training: 
+
+```bash
+
+    in the CFG class,
+
+    valid_id = '20230820203112' #change this to the segment you want to use as a validation segment
+
+    in the get_train_valid_dataset function
+
+    under for fragment_id_ink [] #insert the segments you want to use for training that you have located in train_scrolls, including your valid segment
+
+    towards the bottom under fragments=['20231005123336'] #change this to include each valid segment you want to use in a fold, so for if you have 1 you will have 1 valid segment and it will run the number of defined epochs with that valid. if you have 2 here it will do 2 full training runs with two different valid sets
+
+```
+
+
+
+train_timesformer_og.py and train_timesformer_deduped.py do not accept any arguments, but most of the parameters are the same as described above.
+


### PR DESCRIPTION
modify to reference / guide docker with latest version from philip. it is the easiest to run for new users, in my experience. its also what the current seg team is using, so if anyone needs help they're going to want to be running it. 

the campfire stuff is nice, but perhaps in the future this could be changed to just be a tutorial on straight volume data, as most people seem to get stuck in the weeds on the campfire tutorial, based on what i've seen in newbie-questions

will be adding khartes in the coming days as well along with videos for both.